### PR TITLE
Add NextIntl translations for portfolio

### DIFF
--- a/app/[locale]/components/about.jsx
+++ b/app/[locale]/components/about.jsx
@@ -1,8 +1,10 @@
 import { useUserStore } from "@/store/store";
 import Image from "next/image";
 import gabiPic from "../../../public/gabi.png";
+import {useTranslations} from "@/i18n/client";
 
 const About = () => {
+  const t = useTranslations('About');
   const userSkills = useUserStore((state) => state.skill);
   const userPhrases = useUserStore((state) => state.phrases);
   const hardSkillsList = userSkills.map(
@@ -19,8 +21,8 @@ const About = () => {
   );
   return (
     <div id="about" className="w-full px-[12%] py-10 scroll-mt-20">
-      <h4 className="text-center mb-2 text-lg font-Ovo">Introduction</h4>
-      <h2 className="text-center text-5xl font-Ovo">About Me</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('introduction')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('aboutMe')}</h2>
       <div className="flex w-full flex-col lg:flex-row items-center gap-20 my-20">
         <div className="w-64 sm:w-80 rounded-3xl max-w-none">
           <Image
@@ -31,7 +33,7 @@ const About = () => {
         </div>
         <div className="flex-1">
           <p className="mb-10 max-w-2xl font-Ovo">{userPhrases.mainPhrase}</p>
-          <h4 className="text-center mb-4 text-lg font-Ovo">Technologies</h4>
+          <h4 className="text-center mb-4 text-lg font-Ovo">{t('technologies')}</h4>
           <ul
             className="grid grid-cols-2 sm:grid-cols-3 gap-7 max-w-2xl md:border-[0.5px] border-gray-400 rounded-xl p-6 
              cursor-pointer hover:bg-lightHover hover:-translate-y-1 duration-500 hover:shadow-black 

--- a/app/[locale]/components/contact.jsx
+++ b/app/[locale]/components/contact.jsx
@@ -3,8 +3,10 @@
 import { useRef, useState, useEffect } from "react";
 import toast from "react-hot-toast";
 import { IconArrowNarrowRight } from '@tabler/icons-react';
+import {useTranslations} from "@/i18n/client";
 
 const Contact = () => {
+  const t = useTranslations('Contact');
   const formRef = useRef();
   const [isFormValid, setIsFormValid] = useState(false);
   const [userMessage, setUserMessage] = useState("");
@@ -50,11 +52,10 @@ const Contact = () => {
 
   return (
     <div id="contact" className="w-full px-[12%] py-10 scroll-mt-20 overflow-x-hidden">
-      <h4 className="text-center mb-2 text-lg font-Ovo">Connect with me</h4>
-      <h2 className="text-center text-5xl font-Ovo">Get in touch</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('connect')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('title')}</h2>
       <p className="text-center max-w-2xl mx-auto mt-15 mb-16 font-Ovo">
-        If you have any questions or would like to collaborate on a project,
-        feel free to reach out!
+        {t('description')}
       </p>
 
       <form
@@ -67,7 +68,7 @@ const Contact = () => {
           <input
             required
             type="text"
-            placeholder="Enter your name"
+            placeholder={t('namePlaceholder')}
             className="w-full sm:flex-1 min-w-0 box-border p-3 h-12 outline-none border-[0.5px] border-gray-400 rounded-md"
             value={userName}
             onChange={(e) => setUserName(e.target.value)}
@@ -75,7 +76,7 @@ const Contact = () => {
           <input
             required
             type="email"
-            placeholder="Enter your email"
+            placeholder={t('emailPlaceholder')}
             className="w-full sm:flex-1 min-w-0 box-border p-3 h-12 outline-none border-[0.5px] border-gray-400 rounded-md"
             value={userEmail}
             onChange={(e) => setUserEmail(e.target.value)}
@@ -86,7 +87,7 @@ const Contact = () => {
           required
           cols="30"
           rows="6"
-          placeholder="Message"
+          placeholder={t('messagePlaceholder')}
           className="w-full p-4 outline-none border-[0.5px] border-gray-400 rounded-md bg-white mb-6"
           value={userMessage}
           onChange={(e) => setUserMessage(e.target.value)}
@@ -102,12 +103,12 @@ const Contact = () => {
           className={`w-max flex items-center justify-center gap-2 text-gray-700 border-[0.5px] border-gray-700 rounded-full py-3 px-10 mx-auto my-20 hover:bg-lightHover duration-500 dark:text-white dark:border-white dark:hover:bg-darkHover font-Ovo ${isFormValid ? "cursor-pointer" : "cursor-not-allowed"}`}
           disabled={!isFormValid}
         >
-          Send
+          {t('send')}
           <IconArrowNarrowRight stroke={1} />
         </button>
 
         <div className="h-10">
-          {isSending && <p className="text-center mt-4">sending...</p>}
+          {isSending && <p className="text-center mt-4">{t('sending')}</p>}
         </div>
       </form>
     </div>

--- a/app/[locale]/components/experience.jsx
+++ b/app/[locale]/components/experience.jsx
@@ -1,14 +1,16 @@
 import { useUserStore } from "@/store/store";
+import {useTranslations} from "@/i18n/client";
 
 const Experience = () => {
+  const t = useTranslations('Experience');
   const userExperiences = useUserStore((state) => state.experiences);
 
   return (
     <div id="experience" className="w-full px-[12%] py-10 scroll-mt-20">
-      <h4 className="text-center mb-2 text-lg font-Ovo">My Job history</h4>
-      <h2 className="text-center text-5xl font-Ovo">Experience</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('jobHistory')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('title')}</h2>
       <p className="text-center max-w-2xl mx-auto mt-15 mb-16 font-Ovo">
-        Here are some of the companies I&apos;ve worked for in the past
+        {t('description')}
       </p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/app/[locale]/components/footer.jsx
+++ b/app/[locale]/components/footer.jsx
@@ -5,8 +5,10 @@ import { IconMailForward } from '@tabler/icons-react';
 import Link from "next/link";
 import { useUserStore } from "@/store/store";
 import PropTypes from "prop-types";
+import {useTranslations} from "@/i18n/client";
 
 const Footer = ({ isDarkMode }) => {
+    const t = useTranslations('Footer');
     const socialMedia = useUserStore((state) => state.social || []);
 
     const socialMediaList = socialMedia.map((socialMedia) => (
@@ -43,7 +45,7 @@ const Footer = ({ isDarkMode }) => {
             </div>
 
             <div className="text-center sm:flex items-center justify-between border-t border-gray-400 mx-[10%] mt-12 py-2">
-                <p>© 2025 Gabriel Maglia. All rights reserved.</p>
+                <p>{t('rights')}</p>
                 <div className={`flex gap-3 items-center justify-evenly px-4 py-2 rounded-full shadow-sm  ${isDarkMode ? " bg-white shadow-sm bg-opacity-20" : ""}  font-Ovo`}>
                     {socialMediaList}
                 </div>

--- a/app/[locale]/components/header.jsx
+++ b/app/[locale]/components/header.jsx
@@ -2,8 +2,10 @@ import React from "react";
 import Image from "next/image";
 import gabiPic from '../../../public/gabi.png'
 import { IconDownload, IconContract } from '@tabler/icons-react';
+import {useTranslations} from "@/i18n/client";
 
 const Header = () => {
+    const t = useTranslations('Header');
     return (
         <div className="w-[100vw] h-screen flex items-center justify-center" id="top">
             <div className="w-11/12 max-w-3xl text-center mx-auto h-screen flex flex-col items-center justify-center gap-4 ">
@@ -14,12 +16,10 @@ const Header = () => {
                         className="object-contain w-32"
                     />
                 </div>
-                <h3 className="flex items-end gap-2 text-xl md:text-2xl mb-3 font-Ovo"> {`Hi I am Gabriel Maglia`}  </h3>
-                <h1 className=" text-3xl sm:text-6xl lg:text-[66px] font-Ovo " > frontend web developer based in Rosario </h1>
+                <h3 className="flex items-end gap-2 text-xl md:text-2xl mb-3 font-Ovo"> {t('greeting')}  </h3>
+                <h1 className=" text-3xl sm:text-6xl lg:text-[66px] font-Ovo " > {t('title')} </h1>
                 <p className="max-w-2xl mx-auto font-Ovo" >
-                    Welcome to my personal portfolio where you can learn something about
-                    me and look for my works, you can also contact with me, I will be in
-                    touch in no time!
+                    {t('description')}
                 </p>
                 <div className="flex flex-col sm:flex-row items-center gap-4 mt-4">
                     <a
@@ -27,7 +27,7 @@ const Header = () => {
                         href="#contact"
                      
                     >
-                        Contact Me
+                        {t('contactMe')}
                     <IconContract stroke={1} />
                     </a>
                     <a
@@ -36,7 +36,7 @@ const Header = () => {
                         download
                        
                     >
-                        My Resume
+                        {t('myResume')}
                     <IconDownload stroke={1} />
                     </a>
                 </div>

--- a/app/[locale]/components/navbar.jsx
+++ b/app/[locale]/components/navbar.jsx
@@ -7,8 +7,10 @@ import logo from "../../../public/Logo.png";
 import Link from "next/link";
 import { useUserStore } from "@/store/store";
 import { IconMoon, IconSun, IconMenuDeep, IconSquareRoundedX } from "@tabler/icons-react";
+import {useTranslations} from "@/i18n/client";
 
 const Navbar = ({isDarkMode, setIsDarkMode}) => {
+    const t = useTranslations('Navbar');
     const [isScroll, setIsScroll] = useState(false);
     const socialMedia = useUserStore((state) => state.social);
     const sideMenuRef = useRef(null);
@@ -66,28 +68,28 @@ const Navbar = ({isDarkMode, setIsDarkMode}) => {
                 <ul className={`hidden md:flex items-center gap-6 lg:gap-8 rounded-full px-12 py-3 dark:border dark:border-white/50 dark:bg-transparent ${!isScroll ? "bg-white shadow-sm bg-opacity-50 " : ""}`}>
                     <li>
                         <a className="font-Ovo" href="#top">
-                            Home
+                            {t('home')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#about">
-                            About
+                            {t('about')}
                         </a>
                     </li>
                   
                     <li>
                         <a className="font-Ovo" href="#work">
-                            My Work
+                            {t('work')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#experience">
-                            Experience
+                            {t('experience')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#contact">
-                            Contact Me
+                            {t('contact')}
                         </a>
                     </li>
                 </ul>
@@ -110,27 +112,27 @@ const Navbar = ({isDarkMode, setIsDarkMode}) => {
                     
                     <li>
                         <a className="font-Ovo" href="#top">
-                            Home
+                            {t('home')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#about">
-                            About
+                            {t('about')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#work">
-                            My Work
+                            {t('work')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#experience">
-                            Experience
+                            {t('experience')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#contact">
-                            Contact Me
+                            {t('contact')}
                         </a>
                     </li>
                 </ul>

--- a/app/[locale]/components/work.jsx
+++ b/app/[locale]/components/work.jsx
@@ -5,8 +5,10 @@ import { useUserStore } from "@/store/store";
 import { IconSend, IconArrowMoveDown, IconArrowMoveUp } from "@tabler/icons-react";
 import ProjectModal from "./project-modal";
 import ProjectDetail from "./project-detail";
+import {useTranslations} from "@/i18n/client";
 
 const Work = () => {
+  const t = useTranslations('Work');
   const userProyects = useUserStore((state) => state.proyects);
   const [expanded, setExpanded] = useState(false);
 
@@ -42,11 +44,10 @@ const Work = () => {
 
   return (
     <div id="work" className="w-full px-[12%] py-10 scroll-mt-20">
-      <h4 className="text-center mb-2 text-lg font-Ovo">My portfolio</h4>
-      <h2 className="text-center text-5xl font-Ovo">My latest work</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('portfolio')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('latestWork')}</h2>
       <p className="text-center max-w-2xl mx-auto mt-15 mb-16 font-Ovo">
-        Welcome to my development porfolio! explore a collection of projects
-        showcasing my expertise in front-end development
+        {t('description')}
       </p>
 
       <div
@@ -85,7 +86,7 @@ const Work = () => {
             onClick={toggleShowMore}
             className="w-max flex items-center justify-center gap-2 text-gray-700 border-[0.5px] border-gray-700 rounded-full py-3 px-10 mx-auto my-20 hover:bg-lightHover duration-500 dark:text-white dark:border-white dark:hover:bg-darkHover font-Ovo"
           >
-            {expanded ? "Show less" : "Show more"}
+            {expanded ? t('showLess') : t('showMore')}
             {expanded ? <IconArrowMoveUp stroke={2} /> : <IconArrowMoveDown stroke={2} />}
           </button>
         </div>

--- a/app/[locale]/layout.js
+++ b/app/[locale]/layout.js
@@ -1,5 +1,6 @@
 // app/[locale]/layout.jsx
 import {NextIntlClientProvider} from 'next-intl';
+import {notFound} from 'next/navigation';
 import {
   fetchExperiences,
   fetchProyects,
@@ -11,6 +12,13 @@ import StoreProvider from '@/providers/store-provider';
 
 export default async function LocaleLayout({children, params}) {
   const locale = params?.locale || 'es';
+
+  let messages;
+  try {
+    messages = (await import(`../../messages/${locale}.json`)).default;
+  } catch (error) {
+    notFound();
+  }
 
   // Datos por locale (de tus tablas _es / en)
   const [experiences, proyects, skills, socials, phrases] = await Promise.all([
@@ -28,7 +36,7 @@ export default async function LocaleLayout({children, params}) {
   };
 
   return (
-    <NextIntlClientProvider locale={locale}>
+    <NextIntlClientProvider locale={locale} messages={messages}>
       <StoreProvider data={storeData} locale={locale}>
         {children}
       </StoreProvider>

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -16,7 +16,7 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="es" className="scroll-smooth">
+    <html className="scroll-smooth">
       <head>
         <link
           href="https://db.onlinewebfonts.com/c/20ed319043dc56ddb162f273742b0cbd?family=Linotype+Zootype+W01+Regular"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,2 +1,46 @@
 {
+  "Navbar": {
+    "home": "Home",
+    "about": "About",
+    "work": "My Work",
+    "experience": "Experience",
+    "contact": "Contact Me"
+  },
+  "Header": {
+    "greeting": "Hi I am Gabriel Maglia",
+    "title": "frontend web developer based in Rosario",
+    "description": "Welcome to my personal portfolio where you can learn something about me and look for my works, you can also contact with me, I will be in touch in no time!",
+    "contactMe": "Contact Me",
+    "myResume": "My Resume"
+  },
+  "About": {
+    "introduction": "Introduction",
+    "aboutMe": "About Me",
+    "technologies": "Technologies"
+  },
+  "Work": {
+    "portfolio": "My portfolio",
+    "latestWork": "My latest work",
+    "description": "Welcome to my development portfolio! explore a collection of projects showcasing my expertise in front-end development",
+    "showMore": "Show more",
+    "showLess": "Show less"
+  },
+  "Experience": {
+    "jobHistory": "My Job history",
+    "title": "Experience",
+    "description": "Here are some of the companies I've worked for in the past"
+  },
+  "Contact": {
+    "connect": "Connect with me",
+    "title": "Get in touch",
+    "description": "If you have any questions or would like to collaborate on a project, feel free to reach out!",
+    "namePlaceholder": "Enter your name",
+    "emailPlaceholder": "Enter your email",
+    "messagePlaceholder": "Message",
+    "send": "Send",
+    "sending": "sending..."
+  },
+  "Footer": {
+    "rights": "© 2025 Gabriel Maglia. All rights reserved."
+  }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,2 +1,46 @@
 {
+  "Navbar": {
+    "home": "Inicio",
+    "about": "Sobre mí",
+    "work": "Mi trabajo",
+    "experience": "Experiencia",
+    "contact": "Contáctame"
+  },
+  "Header": {
+    "greeting": "Hola soy Gabriel Maglia",
+    "title": "desarrollador web frontend con base en Rosario",
+    "description": "Bienvenido a mi portafolio personal donde puedes conocer algo sobre mí y ver mis trabajos, también puedes contactarme y estaré en contacto en poco tiempo!",
+    "contactMe": "Contáctame",
+    "myResume": "Mi CV"
+  },
+  "About": {
+    "introduction": "Introducción",
+    "aboutMe": "Sobre mí",
+    "technologies": "Tecnologías"
+  },
+  "Work": {
+    "portfolio": "Mi portafolio",
+    "latestWork": "Mis últimos trabajos",
+    "description": "¡Bienvenido a mi portafolio de desarrollo! Explora una colección de proyectos que muestran mi experiencia en desarrollo front-end",
+    "showMore": "Ver más",
+    "showLess": "Ver menos"
+  },
+  "Experience": {
+    "jobHistory": "Mi historial laboral",
+    "title": "Experiencia",
+    "description": "Estas son algunas de las empresas para las que he trabajado"
+  },
+  "Contact": {
+    "connect": "Conecta conmigo",
+    "title": "Ponerse en contacto",
+    "description": "Si tenés alguna pregunta o te gustaría colaborar en un proyecto, no dudes en contactarme",
+    "namePlaceholder": "Ingresá tu nombre",
+    "emailPlaceholder": "Ingresá tu email",
+    "messagePlaceholder": "Mensaje",
+    "send": "Enviar",
+    "sending": "enviando..."
+  },
+  "Footer": {
+    "rights": "© 2025 Gabriel Maglia. Todos los derechos reservados."
+  }
 }


### PR DESCRIPTION
## Summary
- provide English and Spanish dictionaries
- load messages per locale and expose via `NextIntlClientProvider`
- render navbar, contact form and other components with `useTranslations`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87ee28a5c8333a8001fa1b6f36687