### PR TITLE
feat: add internationalization with next-intl

### DIFF
--- a/app/[locale]/layout.js
+++ b/app/[locale]/layout.js
@@ -1,7 +1,3 @@
-import { Outfit, Ovo } from "next/font/google";
-
-import "../globals.css";
-
 import {
   fetchExperiences,
   fetchProyects,
@@ -9,7 +5,6 @@ import {
   fetchSocials,
   fetchUserPhrases,
 } from "@/lib/queries";
-
 import StoreProvider from "@/providers/store-provider";
 import { ToasterProvider } from "@/providers/toast-provider";
 import { ScrollToTop } from "@/components/scrollToTop";
@@ -17,19 +12,11 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 import { locales } from "@/i18n";
 
-const outfit = Outfit({ weight: ["400", "500", "600", "700"], subsets: ["latin"] });
-const ovo = Ovo({ weight: ["400"], subsets: ["latin"] });
-
-export const metadata = {
-  title: "Gabriel Maglia",
-  description: "Gabriel Maglia personal page",
-};
-
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
 }
 
-export default async function RootLayout({ children, params: { locale } }) {
+export default async function LocaleLayout({ children, params: { locale } }) {
   setRequestLocale(locale);
   const messages = await getMessages();
 
@@ -52,21 +39,11 @@ export default async function RootLayout({ children, params: { locale } }) {
   };
 
   return (
-    <html lang={locale} className="scroll-smooth dark:">
-      <head>
-        <link
-          href="https://db.onlinewebfonts.com/c/20ed319043dc56ddb162f273742b0cbd?family=Linotype+Zootype+W01+Regular"
-          rel="stylesheet"
-        />
-      </head>
-      <body className={`${ovo.className} ${outfit.className} w-[100vw] h-screen flex align-middle antialiased leading-8 overflow-x-hidden dark:bg-darkTheme dark:text-white `}>
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <ToasterProvider />
-          <ScrollToTop />
-          <StoreProvider data={data} />
-          {children}
-        </NextIntlClientProvider>
-      </body>
-    </html>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <ToasterProvider />
+      <ScrollToTop />
+      <StoreProvider data={data} />
+      {children}
+    </NextIntlClientProvider>
   );
 }

--- a/app/[locale]/layout.js
+++ b/app/[locale]/layout.js
@@ -1,6 +1,6 @@
 import { Outfit, Ovo } from "next/font/google";
 
-import "./globals.css";
+import "../globals.css";
 
 import {
   fetchExperiences,
@@ -13,24 +13,33 @@ import {
 import StoreProvider from "@/providers/store-provider";
 import { ToasterProvider } from "@/providers/toast-provider";
 import { ScrollToTop } from "@/components/scrollToTop";
+import { NextIntlClientProvider } from "next-intl";
+import { getMessages, setRequestLocale } from "next-intl/server";
+import { locales } from "@/i18n";
 
 const outfit = Outfit({ weight: ["400", "500", "600", "700"], subsets: ["latin"] });
 const ovo = Ovo({ weight: ["400"], subsets: ["latin"] });
-
 
 export const metadata = {
   title: "Gabriel Maglia",
   description: "Gabriel Maglia personal page",
 };
 
-export default async function RootLayout({ children }) {
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export default async function RootLayout({ children, params: { locale } }) {
+  setRequestLocale(locale);
+  const messages = await getMessages();
+
   const [experiences, proyects, skills, socials, phrases] = await Promise.all([
-    fetchExperiences(),
-    fetchProyects(),
+    fetchExperiences(locale),
+    fetchProyects(locale),
     fetchSkills(),
     fetchSocials(),
-    fetchUserPhrases(),
-  ])
+    fetchUserPhrases(locale),
+  ]);
 
   const data = {
     data: phrases[0],
@@ -40,22 +49,23 @@ export default async function RootLayout({ children }) {
       proyects,
       skills,
     },
-  }
+  };
 
   return (
-    <html lang="en" className="scroll-smooth dark:">
-      <head >
+    <html lang={locale} className="scroll-smooth dark:">
+      <head>
         <link
           href="https://db.onlinewebfonts.com/c/20ed319043dc56ddb162f273742b0cbd?family=Linotype+Zootype+W01+Regular"
           rel="stylesheet"
-         
         />
       </head>
       <body className={`${ovo.className} ${outfit.className} w-[100vw] h-screen flex align-middle antialiased leading-8 overflow-x-hidden dark:bg-darkTheme dark:text-white `}>
-        <ToasterProvider />
-        <ScrollToTop />
-        <StoreProvider data={data} />
-        {children}
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <ToasterProvider />
+          <ScrollToTop />
+          <StoreProvider data={data} />
+          {children}
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/app/[locale]/page.jsx
+++ b/app/[locale]/page.jsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useState, useEffect } from 'react'
-import Navbar from "./components/navbar";
-import Header from "./components/header";
-import About from "./components/about";
-import Work from "./components/work";
-import Contact from "./components/contact";
-import Experience from "./components/experience";
-import Footer from "./components/footer";
+import Navbar from "../components/navbar";
+import Header from "../components/header";
+import About from "../components/about";
+import Work from "../components/work";
+import Contact from "../components/contact";
+import Experience from "../components/experience";
+import Footer from "../components/footer";
 const Homepage = () => {
   const [isDarkMode, setIsDarkMode] = useState(true);
 

--- a/app/api/experience/route.js
+++ b/app/api/experience/route.js
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 import { fetchExperiences } from '@/lib/queries'
 
-export async function GET() {
+export async function GET(request) {
+  const { searchParams } = new URL(request.url)
+  const lang = searchParams.get('lang') || 'en'
   try {
-    const experiences = await fetchExperiences()
+    const experiences = await fetchExperiences(lang)
     return NextResponse.json(experiences)
   } catch (err) {
     console.error(err)

--- a/app/api/phrases/route.js
+++ b/app/api/phrases/route.js
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 import { fetchUserPhrases } from '@/lib/queries'
 
-export async function GET() {
+export async function GET(request) {
+  const { searchParams } = new URL(request.url)
+  const lang = searchParams.get('lang') || 'en'
   try {
-    const phrases = await fetchUserPhrases()
+    const phrases = await fetchUserPhrases(lang)
     return NextResponse.json(phrases)
   } catch (err) {
     console.error(err)

--- a/app/api/proyects/route.js
+++ b/app/api/proyects/route.js
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
 import { fetchProyects } from '@/lib/queries'
 
-export async function GET() {
+export async function GET(request) {
+  const { searchParams } = new URL(request.url)
+  const lang = searchParams.get('lang') || 'en'
   try {
-    const proyects = await fetchProyects()
+    const proyects = await fetchProyects(lang)
     return NextResponse.json(proyects)
   } catch (err) {
     console.error(err)

--- a/app/components/about.jsx
+++ b/app/components/about.jsx
@@ -1,10 +1,12 @@
 import { useUserStore } from "@/store/store";
 import Image from "next/image";
 import gabiPic from "../../public/gabi.png";
+import { useTranslations } from "next-intl";
 
 const About = () => {
   const userSkills = useUserStore((state) => state.skill);
   const userPhrases = useUserStore((state) => state.phrases);
+  const t = useTranslations('About');
   const hardSkillsList = userSkills.map(
     (e) =>
       e.type === "hard" && (
@@ -19,8 +21,8 @@ const About = () => {
   );
   return (
     <div id="about" className="w-full px-[12%] py-10 scroll-mt-20">
-      <h4 className="text-center mb-2 text-lg font-Ovo">Introduction</h4>
-      <h2 className="text-center text-5xl font-Ovo">About Me</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('intro')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('title')}</h2>
       <div className="flex w-full flex-col lg:flex-row items-center gap-20 my-20">
         <div className="w-64 sm:w-80 rounded-3xl max-w-none">
           <Image
@@ -31,7 +33,7 @@ const About = () => {
         </div>
         <div className="flex-1">
           <p className="mb-10 max-w-2xl font-Ovo">{userPhrases.mainPhrase}</p>
-          <h4 className="text-center mb-4 text-lg font-Ovo">Technologies</h4>
+          <h4 className="text-center mb-4 text-lg font-Ovo">{t('technologies')}</h4>
           <ul
             className="grid grid-cols-2 sm:grid-cols-3 gap-7 max-w-2xl md:border-[0.5px] border-gray-400 rounded-xl p-6 
              cursor-pointer hover:bg-lightHover hover:-translate-y-1 duration-500 hover:shadow-black 

--- a/app/components/about.jsx
+++ b/app/components/about.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useUserStore } from "@/store/store";
 import Image from "next/image";
 import gabiPic from "../../public/gabi.png";

--- a/app/components/contact.jsx
+++ b/app/components/contact.jsx
@@ -3,6 +3,7 @@
 import { useRef, useState, useEffect } from "react";
 import toast from "react-hot-toast";
 import { IconArrowNarrowRight } from '@tabler/icons-react';
+import { useTranslations } from "next-intl";
 
 const Contact = () => {
   const formRef = useRef();
@@ -12,6 +13,7 @@ const Contact = () => {
   const [userName, setUserName] = useState("");
   const [characters, setCharacters] = useState(0);
   const [isSending, setIsSending] = useState(false);
+  const t = useTranslations('Contact');
 
   useEffect(() => {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -50,11 +52,10 @@ const Contact = () => {
 
   return (
     <div id="contact" className="w-full px-[12%] py-10 scroll-mt-20 overflow-x-hidden">
-      <h4 className="text-center mb-2 text-lg font-Ovo">Connect with me</h4>
-      <h2 className="text-center text-5xl font-Ovo">Get in touch</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('subtitle')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('title')}</h2>
       <p className="text-center max-w-2xl mx-auto mt-15 mb-16 font-Ovo">
-        If you have any questions or would like to collaborate on a project,
-        feel free to reach out!
+        {t('description')}
       </p>
 
       <form
@@ -67,7 +68,7 @@ const Contact = () => {
           <input
             required
             type="text"
-            placeholder="Enter your name"
+            placeholder={t('namePlaceholder')}
             className="w-full sm:flex-1 min-w-0 box-border p-3 h-12 outline-none border-[0.5px] border-gray-400 rounded-md"
             value={userName}
             onChange={(e) => setUserName(e.target.value)}
@@ -75,7 +76,7 @@ const Contact = () => {
           <input
             required
             type="email"
-            placeholder="Enter your email"
+            placeholder={t('emailPlaceholder')}
             className="w-full sm:flex-1 min-w-0 box-border p-3 h-12 outline-none border-[0.5px] border-gray-400 rounded-md"
             value={userEmail}
             onChange={(e) => setUserEmail(e.target.value)}
@@ -86,7 +87,7 @@ const Contact = () => {
           required
           cols="30"
           rows="6"
-          placeholder="Message"
+          placeholder={t('messagePlaceholder')}
           className="w-full p-4 outline-none border-[0.5px] border-gray-400 rounded-md bg-white mb-6"
           value={userMessage}
           onChange={(e) => setUserMessage(e.target.value)}
@@ -95,19 +96,19 @@ const Contact = () => {
         <div
           className={`${characters < 1 ? "opacity-0" : "opacity-100"} ml-auto flex justify-end mt-1 text-lg font-bold text-gray-600`}
         >
-          {characters}
+            {characters}
         </div>
 
         <button
           className={`w-max flex items-center justify-center gap-2 text-gray-700 border-[0.5px] border-gray-700 rounded-full py-3 px-10 mx-auto my-20 hover:bg-lightHover duration-500 dark:text-white dark:border-white dark:hover:bg-darkHover font-Ovo ${isFormValid ? "cursor-pointer" : "cursor-not-allowed"}`}
           disabled={!isFormValid}
         >
-          Send
+          {t('send')}
           <IconArrowNarrowRight stroke={1} />
         </button>
 
         <div className="h-10">
-          {isSending && <p className="text-center mt-4">sending...</p>}
+          {isSending && <p className="text-center mt-4">{t('sending')}</p>}
         </div>
       </form>
     </div>

--- a/app/components/experience.jsx
+++ b/app/components/experience.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useUserStore } from "@/store/store";
 import { useTranslations } from "next-intl";
 

--- a/app/components/experience.jsx
+++ b/app/components/experience.jsx
@@ -1,14 +1,16 @@
 import { useUserStore } from "@/store/store";
+import { useTranslations } from "next-intl";
 
 const Experience = () => {
   const userExperiences = useUserStore((state) => state.experiences);
+  const t = useTranslations('Experience');
 
   return (
     <div id="experience" className="w-full px-[12%] py-10 scroll-mt-20">
-      <h4 className="text-center mb-2 text-lg font-Ovo">My Job history</h4>
-      <h2 className="text-center text-5xl font-Ovo">Experience</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('subtitle')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('title')}</h2>
       <p className="text-center max-w-2xl mx-auto mt-15 mb-16 font-Ovo">
-        Here are some of the companies I&apos;ve worked for in the past
+        {t('description')}
       </p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/app/components/footer.jsx
+++ b/app/components/footer.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import Image from "next/image";
 import logo from "../../public/Logo.png";

--- a/app/components/footer.jsx
+++ b/app/components/footer.jsx
@@ -5,9 +5,11 @@ import { IconMailForward } from '@tabler/icons-react';
 import Link from "next/link";
 import { useUserStore } from "@/store/store";
 import PropTypes from "prop-types";
+import { useTranslations } from "next-intl";
 
 const Footer = ({ isDarkMode }) => {
     const socialMedia = useUserStore((state) => state.social || []);
+    const t = useTranslations('Footer');
 
     const socialMediaList = socialMedia.map((socialMedia) => (
         <div key={socialMedia.name}>
@@ -43,7 +45,7 @@ const Footer = ({ isDarkMode }) => {
             </div>
 
             <div className="text-center sm:flex items-center justify-between border-t border-gray-400 mx-[10%] mt-12 py-2">
-                <p>© 2025 Gabriel Maglia. All rights reserved.</p>
+                <p>© 2025 Gabriel Maglia. {t('rights')}</p>
                 <div className={`flex gap-3 items-center justify-evenly px-4 py-2 rounded-full shadow-sm  ${isDarkMode ? " bg-white shadow-sm bg-opacity-20" : ""}  font-Ovo`}>
                     {socialMediaList}
                 </div>

--- a/app/components/header.jsx
+++ b/app/components/header.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from "react";
 import Image from "next/image";
 import gabiPic from '../../public/gabi.png'

--- a/app/components/header.jsx
+++ b/app/components/header.jsx
@@ -2,8 +2,10 @@ import React from "react";
 import Image from "next/image";
 import gabiPic from '../../public/gabi.png'
 import { IconDownload, IconContract } from '@tabler/icons-react';
+import { useTranslations } from "next-intl";
 
 const Header = () => {
+    const t = useTranslations('Header');
     return (
         <div className="w-[100vw] h-screen flex items-center justify-center" id="top">
             <div className="w-11/12 max-w-3xl text-center mx-auto h-screen flex flex-col items-center justify-center gap-4 ">
@@ -14,29 +16,27 @@ const Header = () => {
                         className="object-contain w-32"
                     />
                 </div>
-                <h3 className="flex items-end gap-2 text-xl md:text-2xl mb-3 font-Ovo"> {`Hi I am Gabriel Maglia`}  </h3>
-                <h1 className=" text-3xl sm:text-6xl lg:text-[66px] font-Ovo " > frontend web developer based in Rosario </h1>
+                <h3 className="flex items-end gap-2 text-xl md:text-2xl mb-3 font-Ovo"> {t('greeting')}  </h3>
+                <h1 className=" text-3xl sm:text-6xl lg:text-[66px] font-Ovo " > {t('headline')} </h1>
                 <p className="max-w-2xl mx-auto font-Ovo" >
-                    Welcome to my personal portfolio where you can learn something about
-                    me and look for my works, you can also contact with me, I will be in
-                    touch in no time!
+                    {t('description')}
                 </p>
                 <div className="flex flex-col sm:flex-row items-center gap-4 mt-4">
                     <a
                         className="px-10 py-3 border border-white rounded-full bg-black text-white flex items-center gap-2"
                         href="#contact"
-                     
+
                     >
-                        Contact Me
+                        {t('contact')}
                     <IconContract stroke={1} />
                     </a>
                     <a
                         className="px-10 py-3 border rounded-full border-gray-500 flex items-center gap-2"
                         href="/Gabriel Maglia - Fullstack Developer ESP.pdf"
                         download
-                       
+
                     >
-                        My Resume
+                        {t('resume')}
                     <IconDownload stroke={1} />
                     </a>
                 </div>

--- a/app/components/navbar.jsx
+++ b/app/components/navbar.jsx
@@ -7,11 +7,15 @@ import logo from "../../public/Logo.png";
 import Link from "next/link";
 import { useUserStore } from "@/store/store";
 import { IconMoon, IconSun, IconMenuDeep, IconSquareRoundedX } from "@tabler/icons-react";
+import { useTranslations, useLocale } from "next-intl";
 
 const Navbar = ({isDarkMode, setIsDarkMode}) => {
     const [isScroll, setIsScroll] = useState(false);
     const socialMedia = useUserStore((state) => state.social);
     const sideMenuRef = useRef(null);
+    const t = useTranslations('Navbar');
+    const locale = useLocale();
+    const otherLocale = locale === 'en' ? 'es' : 'en';
 
     const openMenu = () => {
         sideMenuRef.current.style.transform = "translateX(-16rem)";
@@ -66,28 +70,28 @@ const Navbar = ({isDarkMode, setIsDarkMode}) => {
                 <ul className={`hidden md:flex items-center gap-6 lg:gap-8 rounded-full px-12 py-3 dark:border dark:border-white/50 dark:bg-transparent ${!isScroll ? "bg-white shadow-sm bg-opacity-50 " : ""}`}>
                     <li>
                         <a className="font-Ovo" href="#top">
-                            Home
+                            {t('home')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#about">
-                            About
+                            {t('about')}
                         </a>
                     </li>
                   
                     <li>
                         <a className="font-Ovo" href="#work">
-                            My Work
+                            {t('work')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#experience">
-                            Experience
+                            {t('experience')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#contact">
-                            Contact Me
+                            {t('contact')}
                         </a>
                     </li>
                 </ul>
@@ -98,6 +102,9 @@ const Navbar = ({isDarkMode, setIsDarkMode}) => {
                     <div className={`hidden lg:flex gap-3 items-center px-10 py-2.5  rounded-full ml-4 shadow-sm  ${isDarkMode ? " bg-white shadow-sm bg-opacity-20" : ""} ${isScroll ? "bg-none border-none shadow-none" : ""} ${!isScroll ? "bg-white shadow-sm bg-opacity-50" : ""} font-Ovo`}>
                         {socialMediaList}
                     </div>
+                    <Link href="/" locale={otherLocale} className="font-Ovo">
+                        {otherLocale.toUpperCase()}
+                    </Link>
                     <button onClick={openMenu} className="block md:hidden ml-3">
                         <IconMenuDeep stroke={1} />
                     </button>
@@ -110,28 +117,33 @@ const Navbar = ({isDarkMode, setIsDarkMode}) => {
                     
                     <li>
                         <a className="font-Ovo" href="#top">
-                            Home
+                            {t('home')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#about">
-                            About
+                            {t('about')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#work">
-                            My Work
+                            {t('work')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#experience">
-                            Experience
+                            {t('experience')}
                         </a>
                     </li>
                     <li>
                         <a className="font-Ovo" href="#contact">
-                            Contact Me
+                            {t('contact')}
                         </a>
+                    </li>
+                    <li>
+                        <Link href="/" locale={otherLocale} className="font-Ovo">
+                            {otherLocale.toUpperCase()}
+                        </Link>
                     </li>
                 </ul>
             </nav>

--- a/app/components/project-detail.jsx
+++ b/app/components/project-detail.jsx
@@ -3,8 +3,10 @@
 import { useMemo, useState, useEffect, useCallback } from 'react';
 import Image from 'next/image';
 import { IconBrandGithub, IconExternalLink, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
 
 export default function ProjectDetail({ project }) {
+  const t = useTranslations('ProjectDetail');
   const images = useMemo(() => {
     if (!project) return [];
     return [project.img1_pro, project.img2_pro, project.img3_pro].filter(Boolean);
@@ -50,7 +52,7 @@ export default function ProjectDetail({ project }) {
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-gray-500 dark:text-gray-400">
-              No images available
+              {t('noImages')}
             </div>
           )}
         </div>
@@ -103,7 +105,7 @@ export default function ProjectDetail({ project }) {
             className="inline-flex items-center justify-center gap-2 rounded-full px-5 py-3 border border-gray-700 dark:border-white text-gray-800 dark:text-white hover:bg-lightHover dark:hover:bg-darkHover transition"
           >
             <IconExternalLink size={20} />
-            Live Demo
+            {t('liveDemo')}
           </a>
         )}
         {project.githubLink_pro && (
@@ -114,7 +116,7 @@ export default function ProjectDetail({ project }) {
             className="inline-flex items-center justify-center gap-2 rounded-full px-5 py-3 border border-gray-700 dark:border-white text-gray-800 dark:text-white hover:bg-lightHover dark:hover:bg-darkHover transition"
           >
             <IconBrandGithub size={20} />
-            GitHub
+            {t('github')}
           </a>
         )}
       </div>

--- a/app/components/project-modal.jsx
+++ b/app/components/project-modal.jsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useRef } from 'react';
 import { IconX } from '@tabler/icons-react';
+import { useTranslations } from 'next-intl';
 
 export default function ProjectModal({ open, onClose, children }) {
   const overlayRef = useRef(null);
   const dialogRef = useRef(null);
+  const t = useTranslations('ProjectModal');
 
   // Cerrar con ESC
   useEffect(() => {
@@ -43,7 +45,7 @@ export default function ProjectModal({ open, onClose, children }) {
       >
         {/* Header modal */}
         <div className="flex items-center justify-between mb-4">
-          <div className="text-sm text-gray-500 dark:text-gray-400">Project Details</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400">{t('title')}</div>
           <button
             onClick={onClose}
             aria-label="Close"

--- a/app/components/work.jsx
+++ b/app/components/work.jsx
@@ -5,10 +5,12 @@ import { useUserStore } from "@/store/store";
 import { IconSend, IconArrowMoveDown, IconArrowMoveUp } from "@tabler/icons-react";
 import ProjectModal from "./project-modal";
 import ProjectDetail from "./project-detail";
+import { useTranslations } from "next-intl";
 
 const Work = () => {
   const userProyects = useUserStore((state) => state.proyects);
   const [expanded, setExpanded] = useState(false);
+  const t = useTranslations('Work');
 
   const gridRef = useRef(null);
   const [maxHeight, setMaxHeight] = useState(0);
@@ -42,11 +44,10 @@ const Work = () => {
 
   return (
     <div id="work" className="w-full px-[12%] py-10 scroll-mt-20">
-      <h4 className="text-center mb-2 text-lg font-Ovo">My portfolio</h4>
-      <h2 className="text-center text-5xl font-Ovo">My latest work</h2>
+      <h4 className="text-center mb-2 text-lg font-Ovo">{t('portfolio')}</h4>
+      <h2 className="text-center text-5xl font-Ovo">{t('title')}</h2>
       <p className="text-center max-w-2xl mx-auto mt-15 mb-16 font-Ovo">
-        Welcome to my development porfolio! explore a collection of projects
-        showcasing my expertise in front-end development
+        {t('description')}
       </p>
 
       <div
@@ -85,7 +86,7 @@ const Work = () => {
             onClick={toggleShowMore}
             className="w-max flex items-center justify-center gap-2 text-gray-700 border-[0.5px] border-gray-700 rounded-full py-3 px-10 mx-auto my-20 hover:bg-lightHover duration-500 dark:text-white dark:border-white dark:hover:bg-darkHover font-Ovo"
           >
-            {expanded ? "Show less" : "Show more"}
+            {expanded ? t('showLess') : t('showMore')}
             {expanded ? <IconArrowMoveUp stroke={2} /> : <IconArrowMoveDown stroke={2} />}
           </button>
         </div>

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,28 @@
+import { Outfit, Ovo } from 'next/font/google';
+import './globals.css';
+import { getLocale } from 'next-intl/server';
+
+const outfit = Outfit({ weight: ['400', '500', '600', '700'], subsets: ['latin'] });
+const ovo = Ovo({ weight: ['400'], subsets: ['latin'] });
+
+export const metadata = {
+  title: 'Gabriel Maglia',
+  description: 'Gabriel Maglia personal page',
+};
+
+export default async function RootLayout({ children }) {
+  const locale = await getLocale();
+  return (
+    <html lang={locale} className="scroll-smooth dark:">
+      <head>
+        <link
+          href="https://db.onlinewebfonts.com/c/20ed319043dc56ddb162f273742b0cbd?family=Linotype+Zootype+W01+Regular"
+          rel="stylesheet"
+        />
+      </head>
+      <body className={`${ovo.className} ${outfit.className} w-[100vw] h-screen flex align-middle antialiased leading-8 overflow-x-hidden dark:bg-darkTheme dark:text-white`}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+import { defaultLocale } from '@/i18n';
+
+export default function RootPage() {
+  redirect(`/${defaultLocale}`);
+}

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,7 @@
+export const locales = ['en', 'es'];
+export const defaultLocale = 'en';
+
+export default {
+  locales,
+  defaultLocale
+};

--- a/i18n.js
+++ b/i18n.js
@@ -1,7 +1,12 @@
+import {getRequestConfig} from 'next-intl/server';
+
 export const locales = ['en', 'es'];
 export const defaultLocale = 'en';
 
-export default {
-  locales,
-  defaultLocale
-};
+export default getRequestConfig(async ({locale}) => {
+  const resolvedLocale = locale ?? defaultLocale;
+  return {
+    locale: resolvedLocale,
+    messages: (await import(`./messages/${resolvedLocale}.json`)).default
+  };
+});

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,9 +1,14 @@
 import { db } from '@/lib/db'
-import { experience, proyect, skills, social, userPhrases } from '@/lib/schema'
+import { experience, proyect, skills, social, userPhrases, experienceEs, proyectEs, userPhrasesEs } from '@/lib/schema'
+export const fetchExperiences = async (locale = 'en') =>
+  locale === 'es' ? db.select().from(experienceEs) : db.select().from(experience)
 
-export const fetchExperiences = async () => db.select().from(experience)
-export const fetchProyects = async () => db.select().from(proyect)
+export const fetchProyects = async (locale = 'en') =>
+  locale === 'es' ? db.select().from(proyectEs) : db.select().from(proyect)
+
 export const fetchSkills = async () => db.select().from(skills)
 export const fetchSocials = async () => db.select().from(social)
-export const fetchUserPhrases = async () => db.select().from(userPhrases)
+
+export const fetchUserPhrases = async (locale = 'en') =>
+  locale === 'es' ? db.select().from(userPhrasesEs) : db.select().from(userPhrases)
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -15,7 +15,29 @@ export const experience = pgTable('Experiences', {
   img_exp: text('img_exp'),
 })
 
+export const experienceEs = pgTable('Experiences_es', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  title_exp: text('title_exp'),
+  institution_exp: text('institution_exp'),
+  startDate_exp: text('startDate_exp'),
+  endDate_exp: text('endDate_exp'),
+  description_exp: text('description_exp'),
+  img_exp: text('img_exp'),
+})
+
 export const proyect = pgTable('Proyects', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  title_pro: text('title_pro'),
+  technologies_pro: text('technologies_pro'),
+  description_pro: text('description_pro'),
+  deployLink_pro: text('deployLink_pro'),
+  githubLink_pro: text('githubLink_pro'),
+  img1_pro: text('img1_pro'),
+  img2_pro: text('img2_pro'),
+  img3_pro: text('img3_pro'),
+})
+
+export const proyectEs = pgTable('Proyects_es', {
   id: uuid('id').defaultRandom().primaryKey(),
   title_pro: text('title_pro'),
   technologies_pro: text('technologies_pro'),
@@ -44,6 +66,14 @@ export const social = pgTable('SocialMedia', {
 })
 
 export const userPhrases = pgTable('UserPhrases', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  main_phrase: text('main_phrase'),
+  phrase1: text('phrase1'),
+  phrase2: text('phrase2'),
+  phrase3: text('phrase3'),
+})
+
+export const userPhrasesEs = pgTable('UserPhrases_es', {
   id: uuid('id').defaultRandom().primaryKey(),
   main_phrase: text('main_phrase'),
   phrase1: text('phrase1'),

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,54 @@
+{
+  "Navbar": {
+    "home": "Home",
+    "about": "About",
+    "work": "My Work",
+    "experience": "Experience",
+    "contact": "Contact Me"
+  },
+  "Header": {
+    "greeting": "Hi I am Gabriel Maglia",
+    "headline": "frontend web developer based in Rosario",
+    "description": "Welcome to my personal portfolio where you can learn something about me and look for my works, you can also contact with me, I will be in touch in no time!",
+    "contact": "Contact Me",
+    "resume": "My Resume"
+  },
+  "About": {
+    "intro": "Introduction",
+    "title": "About Me",
+    "technologies": "Technologies"
+  },
+  "Work": {
+    "portfolio": "My portfolio",
+    "title": "My latest work",
+    "description": "Welcome to my development portfolio! explore a collection of projects showcasing my expertise in front-end development",
+    "showMore": "Show more",
+    "showLess": "Show less"
+  },
+  "Experience": {
+    "subtitle": "My Job history",
+    "title": "Experience",
+    "description": "Here are some of the companies I've worked for in the past"
+  },
+  "Contact": {
+    "subtitle": "Connect with me",
+    "title": "Get in touch",
+    "description": "If you have any questions or would like to collaborate on a project, feel free to reach out!",
+    "namePlaceholder": "Enter your name",
+    "emailPlaceholder": "Enter your email",
+    "messagePlaceholder": "Message",
+    "send": "Send",
+    "sending": "sending..."
+  },
+  "Footer": {
+    "rights": "All rights reserved."
+  },
+  "ProjectModal": {
+    "title": "Project Details"
+  },
+  "ProjectDetail": {
+    "noImages": "No images available",
+    "liveDemo": "Live Demo",
+    "github": "GitHub"
+  }
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,54 @@
+{
+  "Navbar": {
+    "home": "Inicio",
+    "about": "Sobre mí",
+    "work": "Mis Proyectos",
+    "experience": "Experiencia",
+    "contact": "Contáctame"
+  },
+  "Header": {
+    "greeting": "Hola soy Gabriel Maglia",
+    "headline": "desarrollador web frontend basado en Rosario",
+    "description": "Bienvenido a mi portafolio personal donde puedes conocer algo sobre mí y ver mis trabajos, también puedes contactarte conmigo, ¡responderé en poco tiempo!",
+    "contact": "Contáctame",
+    "resume": "Mi Currículum"
+  },
+  "About": {
+    "intro": "Introducción",
+    "title": "Sobre mí",
+    "technologies": "Tecnologías"
+  },
+  "Work": {
+    "portfolio": "Mi portafolio",
+    "title": "Mis últimos trabajos",
+    "description": "¡Bienvenido a mi portafolio de desarrollo! explora una colección de proyectos que muestran mi experiencia en desarrollo front-end",
+    "showMore": "Ver más",
+    "showLess": "Ver menos"
+  },
+  "Experience": {
+    "subtitle": "Mi historial laboral",
+    "title": "Experiencia",
+    "description": "Aquí están algunas de las empresas para las que he trabajado"
+  },
+  "Contact": {
+    "subtitle": "Conecta conmigo",
+    "title": "Ponte en contacto",
+    "description": "Si tienes alguna pregunta o te gustaría colaborar en un proyecto, ¡no dudes en escribirme!",
+    "namePlaceholder": "Ingresa tu nombre",
+    "emailPlaceholder": "Ingresa tu correo",
+    "messagePlaceholder": "Mensaje",
+    "send": "Enviar",
+    "sending": "enviando..."
+  },
+  "Footer": {
+    "rights": "Todos los derechos reservados."
+  },
+  "ProjectModal": {
+    "title": "Detalles del proyecto"
+  },
+  "ProjectDetail": {
+    "noImages": "No hay imágenes disponibles",
+    "liveDemo": "Ver demo",
+    "github": "GitHub"
+  }
+}

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,11 @@
+import createMiddleware from 'next-intl/middleware';
+import {locales, defaultLocale} from './i18n';
+
+export default createMiddleware({
+  locales,
+  defaultLocale
+});
+
+export const config = {
+  matcher: ['/', '/(en|es)/:path*']
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,7 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin('./i18n.js');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     images: {
@@ -11,4 +15,4 @@ const nextConfig = {
       },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "framer-motion": "^11.2.12",
         "lucide-react": "^0.400.0",
         "next": "14.2.4",
+        "next-intl": "^4.3.5",
         "nodemailer": "^7.0.3",
         "pg": "^8.16.0",
         "postgres": "^3.4.5",
@@ -1041,6 +1042,66 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1453,6 +1514,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -2806,6 +2873,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4469,6 +4542,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -5307,6 +5392,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "14.2.4",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.4.tgz",
@@ -5353,6 +5447,33 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.3.5.tgz",
+      "integrity": "sha512-tT3SltfpPOCAQ9kVNr+8t6FUtVf8G0WFlJcVc8zj4WCMfuF8XFk4gZCN/MtjgDgkUISw5aKamOClJB4EsV95WQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "negotiator": "^1.0.0",
+        "use-intl": "^4.3.5"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -7428,6 +7549,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.3.5.tgz",
+      "integrity": "sha512-qyL1TZNesVbzj/75ZbYsi+xzNSiFqp5rIVsiAN0JT8rPMSjX0/3KQz76aJIrngI1/wIQdVYFVdImWh5yAv+dWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "framer-motion": "^11.2.12",
     "lucide-react": "^0.400.0",
     "next": "14.2.4",
+    "next-intl": "^4.3.5",
     "nodemailer": "^7.0.3",
     "pg": "^8.16.0",
     "postgres": "^3.4.5",


### PR DESCRIPTION
## Summary
- configure Next.js for English and Spanish locales via next-intl
- load translated content from locale-specific database tables and dictionaries
- internationalize UI components and add language switcher

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: connect ENETUNREACH 45.32.173.210:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b881e28a508333bef49ead5faf7fa7